### PR TITLE
Add time split support

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ const NS = rssFeedNamespaces = {
   podcastSoundbite: 'podcast:soundbite',
   podcastTranscript: 'podcast:transcript',
   podcastValue: 'podcast:value',
-  podcastValueRecipient: 'podcast:valueRecipient'
+  podcastValueRecipient: 'podcast:valueRecipient',
+  podcastValueTimeSplit: "podcast:valueTimeSplit",
+  podcastRemoteItem: "podcast:remoteItem"
 }
 
 /*

--- a/index.js
+++ b/index.js
@@ -772,8 +772,14 @@ const getItemsWithAttrs = (val, nestedTags = []) => {
         const finalTags = {}
         if (nestedTags && nestedTags.length > 0) {
           for (const nestedTag of nestedTags) {
-            const nestedItem = getItemsWithAttrs(item[nestedTag])
-            finalTags[nestedTag] = nestedItem
+            if (typeof nestedTag === 'string') {
+              const nestedItem = getItemsWithAttrs(item[nestedTag])
+              finalTags[nestedTag] = nestedItem
+            } else {
+              const {tag, nestedTags = []} = nestedTag;
+              const nestedItem = getItemsWithAttrs(item[tag], nestedTags)
+              finalTags[tag] = nestedItem
+            }
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -430,9 +430,9 @@ const GET = exports.GET = {
     https://github.com/Podcastindex-org/podcast-namespace/tree/7c9516937e74b8058d7d49e2b389c7c361cc6a48
   */
   value: function (node) {
-    const valueItems = getItemsWithAttrs(node[NS.podcastValue], [NS.podcastValueRecipient])
+    const valueItems = getItemsWithAttrs(node[NS.podcastValue], [NS.podcastValueRecipient, {tag: NS.podcastValueTimeSplit, nestedTags: [NS.podcastRemoteItem]}])
     let finalValues = null
-
+  
     if (valueItems && valueItems.length > 0) {
       finalValues = []
       for (const valueItem of valueItems) {
@@ -447,11 +447,31 @@ const GET = exports.GET = {
             finalRecipients.push({ address, customKey, customValue, fee, name, split, type })
           }
           finalValue.recipients = finalRecipients
+        }
+        
+        const valueTimeSplits = valueItem.nestedTags && valueItem.nestedTags[NS.podcastValueTimeSplit];
+        if (Array.isArray(valueTimeSplits)) {
+          const finalTimeSplits = [];
+          for (const valueTimeSplit of valueTimeSplits) {
+            const { startTime, duration, remotePercentage } = valueTimeSplit.attrs;
+            const remoteItems = valueItem.nestedTags && valueTimeSplit.nestedTags[NS.podcastRemoteItem];
+            if (Array.isArray(remoteItems)) {
+              for (const remoteItem of remoteItems) {
+                const { feedGuid, itemGuid } = remoteItem.attrs;
+                finalTimeSplits.push({ startTime, duration, remotePercentage, feedGuid, itemGuid });
+              }
+            }
+          }
+  
+          finalValue.timeSplits = finalTimeSplits;
+        }
+  
+        if (Array.isArray(finalValue.recipients) || Array.isArray(finalValue.timeSplits)) {
           finalValues.push(finalValue)
         }
       }
     }
-
+  
     return finalValues
   }
 }


### PR DESCRIPTION
I took a stab at adding the newer `valueTimeSplit` tags. I needed to grab the nested `remoteItem` from the parent `valueTimeSplit` tag, and modified `getItemsWithAttrs` to return another level of nestedTags.

The new `valueTimeSplits` are returned alongside the `valueRecipients` list that was already there
e.g.
```
{
  method: 'keysend',
  suggested: '0.00000005000',
  type: 'lightning',
  recipients: [
    {
      address: '03...a3',
      customKey: 'key',
      customValue: 'value',
      name: 'Some recipient',
      split: '5',
      type: 'node'
    }
  ],
  timeSplits: [
    {
      startTime: '20.051',
      duration: '98.35102',
      remotePercentage: '90',
      feedGuid: '53...48',
      itemGuid: '1e...60'
    }
  ]
}
``` 